### PR TITLE
Add gw support to zsh completion

### DIFF
--- a/_gradle
+++ b/_gradle
@@ -1,4 +1,4 @@
-#compdef gradle gradlew
+#compdef gradle gradlew gw
 
 local curcontext="$curcontext" ret=1
 local cache_policy


### PR DESCRIPTION
I use [gdub](https://github.com/dougborg/gdub), so this adds `gw` to the zsh compdef. Unsure how to do that safely with your bash method, maybe a conditional on the command being defined?

Looks great though. Have this running now, I've added to my dotfiles - https://github.com/DanielThomas/dotfiles/commit/336c5f7800f89bd49a4c1fc7902b683ee32533c6!